### PR TITLE
Custom HTTP Adapter and added NTLM authentication support

### DIFF
--- a/phishfry/account.py
+++ b/phishfry/account.py
@@ -1,20 +1,33 @@
-from .errors import GetError, MailboxNotFound
 from io import BytesIO
 import logging
+
 from lxml import etree
+import requests
+
+from .errors import GetError, MailboxNotFound
 from .mailbox import Mailbox
 from .namespaces import ENS, MNS, SNS, TNS, NSMAP
 from .remediation_result import RemediationResult
-import requests
 
 log = logging.getLogger(__name__)
 
 class Account():
-    def __init__(self, user, password, server="outlook.office365.com", version="Exchange2016", timezone="UTC", proxies={}):
+    def __init__(
+        self,
+        user,
+        password,
+        server="outlook.office365.com",
+        version="Exchange2016",
+        timezone="UTC",
+        proxies={},
+        adapter=requests.adapter.HTTPAdapter(),
+    ):
         self.version = version
         self.session = requests.Session()
         self.user = user
         self.session.auth = (user, password)
+        self.session.mount('http://', adapter)
+        self.session.mount('https://', adapter)
         self.session.headers.update({'Content-Type': 'text/xml; charset=utf-8', 'Accept-Encoding': 'gzip, deflate'})
         self.url = "https://{}/EWS/Exchange.asmx".format(server)
         self.timezone = timezone

--- a/phishfry/account.py
+++ b/phishfry/account.py
@@ -3,13 +3,46 @@ import logging
 
 from lxml import etree
 import requests
+import requests_ntlm
 
 from .errors import GetError, MailboxNotFound
 from .mailbox import Mailbox
 from .namespaces import ENS, MNS, SNS, TNS, NSMAP
 from .remediation_result import RemediationResult
 
+
 log = logging.getLogger(__name__)
+
+
+BASIC = "basic"
+NTLM = "ntlm"
+
+
+AUTH_TYPES_MAP = {
+    BASIC: requests.auth.HTTPBasicAuth,
+    NTLM: requests_ntlm.HttpNtlmAuth,
+}
+
+
+def get_auth(auth_type, user, password):
+    """Return requests.Session.auth-compatible authentication object."""
+
+    logging.debug("getting auth type")
+
+    if auth_type == NTLM:
+        # XXX - Should we look for backslashes first?
+        user = f"\\{user}"
+
+    try:
+        auth_object = AUTH_TYPES_MAP[auth_type](user, password)
+    except KeyError:
+        message = f"auth type {auth_type} not supported by phishfry"
+        logging.error(message)
+        raise ValueError(message)
+    else:
+        logging.debug(f"created {auth_object.__class__.__name__} for auth type {auth_type}")
+        return auth_object
+
 
 class Account():
     def __init__(
@@ -21,11 +54,12 @@ class Account():
         timezone="UTC",
         proxies={},
         adapter=requests.adapter.HTTPAdapter(),
+        auth_type=BASIC,
     ):
         self.version = version
         self.session = requests.Session()
         self.user = user
-        self.session.auth = (user, password)
+        self.session.auth = get_auth(auth_type, user, password)
         self.session.mount('http://', adapter)
         self.session.mount('https://', adapter)
         self.session.headers.update({'Content-Type': 'text/xml; charset=utf-8', 'Accept-Encoding': 'gzip, deflate'})

--- a/phishfry/account.py
+++ b/phishfry/account.py
@@ -53,7 +53,7 @@ class Account():
         version="Exchange2016",
         timezone="UTC",
         proxies={},
-        adapter=requests.adapter.HTTPAdapter(),
+        adapter=requests.adapters.HTTPAdapter(),
         auth_type=BASIC,
     ):
         self.version = version

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     long_description=read('README.md'),
     long_description_content_type='text/markdown',
     keywords='ews exchange microsoft outlook exchange-web-services o365 office365',
-    install_requires=['requests>=2.7', 'lxml>3.0'],
+    install_requires=['requests>=2.7', 'lxml>3.0', 'requests_ntlm'],
     packages=['phishfry'],
     python_requires=">=2.7",
     zip_safe=False,


### PR DESCRIPTION
# Custom HTTP Adapter:

- Default adapter stays the same -- requests.adapters.HTTPAdapter
- You have the option to pass in your own adapter now when creating a `phishfry.Account` object.

Example of use:
```python
import phishfry
import requests

class MyAdapter(requests.adapters.HTTPAdapter):
    """ Custom adapter to override HTTPAdapter.cert_verify()"""

    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)

    def cert_verify(self, conn, url, verify, cert):
        # Do something special
        super().cert_verify(conn=conn, url=url, verify=verify, cert=cert)

# Now I'll add it to phishfry

adapter = MyAdapter()
account = phishfry.Account("username", "password", adapter=adapter)

```
# NTLM authentication support

I've also added NTLM support through the requests_ntlm package. This is the package referenced by the requests documentation for NTLM compatability:

https://requests.readthedocs.io/en/master/user/authentication/#other-authentication

It's also the same package used by exchangelib:

*see `AUTH_TYPE_MAP` here:   https://github.com/ecederstrand/exchangelib/blob/master/exchangelib/transport.py

Example usage:

```python
import phishfry

account = phishfry.Account("username", "password", auth_type="ntlm")

# auth_type is set to 'basic' by default as to not break existing users.
```