### PR TITLE
Fixes #2 - Removed invalid child XML elements

### DIFF
--- a/phishfry/folder.py
+++ b/phishfry/folder.py
@@ -12,12 +12,15 @@ class Folder():
     def ToXML(self):
         # create folder element
         folder = etree.Element("{%s}FolderId" % TNS, Id=self.folder_id)
+        
+        # Don't add 'Mailbox' element as it's not a valid child of
+        #    FolderId XML element.
 
-        # add mailbox reference
-        if self.mailbox.group is None:
-            folder.append(self.mailbox.ToXML())
-        else:
-            folder.append(self.mailbox.group.ToXML())
+        # # add mailbox reference
+        # if self.mailbox.group is None:
+        #     folder.append(self.mailbox.ToXML())
+        # else:
+        #     folder.append(self.mailbox.group.ToXML())
 
         # return the folder element
         return folder
@@ -75,6 +78,8 @@ class DistinguishedFolder(Folder):
         folder = etree.Element("{%s}DistinguishedFolderId" % TNS, Id=self.folder_id)
 
         # add mailbox reference
+        # Mailbox element is valid child of DistinguishedFolderId
+        #    XML element
         if self.mailbox.group is None:
             folder.append(self.mailbox.ToXML())
         else:

--- a/phishfry/message.py
+++ b/phishfry/message.py
@@ -12,11 +12,14 @@ class Message():
         # create item element
         item = etree.Element("{%s}ItemId" % TNS, Id=self.item_id)
 
-        # add mailbox reference
-        if self.mailbox.group is None:
-            item.append(self.mailbox.ToXML())
-        else:
-            item.append(self.mailbox.group.ToXML())
+        # Don't add 'Mailbox' element as it is not a valid child element
+        #    of the ItemId XML element.
+
+        # # add mailbox reference
+        # if self.mailbox.group is None:
+        #     item.append(self.mailbox.ToXML())
+        # else:
+        #     item.append(self.mailbox.group.ToXML())
 
         # return the item element
         return item


### PR DESCRIPTION
Removed `Mailbox` XML element when parent element is `FolderId` or `ItemId` (message) in Phishfry.

This `Mailbox` element was added in `Folder.ToXML()` and `Message.ToXML()` but is an invalid child element in those cases.

Left the `Mailbox` XML element as a child element in `DistinguishedFolder.ToXML()` as it is valid per API documentation.